### PR TITLE
fix: Proper type export

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "lib/**/*.js",
     "lib/**/*d.ts"
   ],
+  "types": "lib/src/index.d.ts",
   "keywords": [
     "convert",
     "converter",


### PR DESCRIPTION
I've been trying to use this package in an NPM TypeScript project, but it didn't recognize the type exports.
I don't know if this was just me or if it hasn't been tested properly, but the line I've added fixed the problem.